### PR TITLE
[modify] header 컴포넌트 fixed nav z-index 추가 및 HTML 마크업 이미지 대체 텍스트 추가

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -467,6 +467,9 @@
   font-size: 12.003px;
   font-weight: 400;
   padding: 4px 8px;
+
+  height: 27px;
+  line-height: 18px;
 }
 
 .menu_dawn span {
@@ -489,6 +492,7 @@
   align-items: center;
   background-color: #fff;
   box-shadow: rgba(0, 0, 0, 0.07) 0px 3px 4px 0px;
+  z-index: 10;
 }
 
 .menu_scroll {

--- a/src/components/header/index.html
+++ b/src/components/header/index.html
@@ -19,7 +19,10 @@
         <div class="top_banner_inner">
           <p>지금 가입하고 인기상품 <span>100</span>원에 받아가세요!</p>
           <button class="top_banner_close">
-            <img src="/src/assets/icons/ico_close_fff_84x841.png" alt="" />
+            <img
+              src="/src/assets/icons/ico_close_fff_84x841.png"
+              alt="상단 배너 닫기"
+            />
           </button>
         </div>
       </div>
@@ -73,7 +76,7 @@
             <div class="icon">
               <div class="icon_wrapper">
                 <div class="location_modal_wrapper">
-                  <img src="/src/assets/icons/Location.png" alt="" />
+                  <img src="/src/assets/icons/Location.png" alt="배송지 등록" />
                   <div class="location_modal">
                     <p>
                       <span>배송지를 등록하고</span><br />구매 가능한 상품을
@@ -87,12 +90,12 @@
                 </div>
                 <div>
                   <a href="">
-                    <img src="/src/assets/icons/Heart.png" alt="" />
+                    <img src="/src/assets/icons/Heart.png" alt="찜한 상품" />
                   </a>
                 </div>
                 <div>
                   <a href="">
-                    <img src="/src/assets/icons/Cart.png" alt="" />
+                    <img src="/src/assets/icons/Cart.png" alt="장바구니" />
                   </a>
                 </div>
               </div>
@@ -104,141 +107,159 @@
         <div class="nav_origin">
           <ul class="menu">
             <li>
-              <a href="/">카테고리</a>
+              <div>카테고리</div>
               <div class="category">
                 <a>
                   <img
                     src="/src/assets/icons/gift_thin_icon_171751.svg"
-                    alt="선물하기"
+                    aria-hidden="true"
                   />
                   <span>선물하기</span>
                 </a>
                 <a>
-                  <img src="/src/assets/icons/Type=_Vegetable.svg" alt="채소" />
+                  <img
+                    src="/src/assets/icons/Type=_Vegetable.svg"
+                    aria-hidden="true"
+                  />
                   <span>채소</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Fruit.svg"
-                    alt="과일,견과,쌀"
+                    aria-hidden="true"
                   />
                   <span>과일 · 견과 · 쌀</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=SeaFood.svg"
-                    alt="수산,해산,건어물"
+                    aria-hidden="true"
                   />
                   <span>수산 · 해산 · 건어물</span>
                 </a>
                 <a>
-                  <img src="/src/assets/icons/Type=Meet.svg" alt="정육,계란" />
+                  <img
+                    src="/src/assets/icons/Type=Meet.svg"
+                    aria-hidden="true"
+                  />
                   <span>정육 · 계란</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Cook.svg"
-                    alt="국,반찬,메인요리"
+                    aria-hidden="true"
                   />
                   <span>국 · 반찬 · 메인요리</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=_Salad.svg"
-                    alt="샐러드,간편식"
+                    aria-hidden="true"
                   />
                   <span>샐러드 · 간편식</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Oil.svg"
-                    alt="면,양념,오일"
+                    aria-hidden="true"
                   />
                   <span>면 · 양념 · 오일</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Coffee.svg"
-                    alt="생수,음료,우유,커피"
+                    aria-hidden="true"
                   />
                   <span>생수 · 음료 · 우유 · 커피</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Snack.svg"
-                    alt="간식,과자,떡"
+                    aria-hidden="true"
                   />
                   <span>간식 · 과자 · 떡</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Bread.svg"
-                    alt="베이커리,치즈,델리"
+                    aria-hidden="true"
                   />
                   <span>베이커리 · 치즈 · 델리</span>
                 </a>
                 <a>
-                  <img src="/src/assets/icons/Type=Health.svg" alt="건강식품" />
+                  <img
+                    src="/src/assets/icons/Type=Health.svg"
+                    aria-hidden="true"
+                  />
                   <span>건강식품</span>
                 </a>
                 <a>
-                  <img src="/src/assets/icons/Type=Wine.svg" alt="와인" />
+                  <img
+                    src="/src/assets/icons/Type=Wine.svg"
+                    aria-hidden="true"
+                  />
                   <span>와인</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=_TraditionalLiquor.svg"
-                    alt="전통주"
+                    aria-hidden="true"
                   />
                   <span>전통주</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=_Detergent.svg"
-                    alt="생활용품,리빙,캠핑"
+                    aria-hidden="true"
                   />
                   <span>생활용품 · 리빙 · 캠핑</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=_Cosmetics.svg"
-                    alt="스킨케어,메이크업"
+                    aria-hidden="true"
                   />
                   <span>스킨케어 · 메이크업</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=shampoo.svg"
-                    alt="헤어,바디,구강"
+                    aria-hidden="true"
                   />
                   <span>헤어 · 바디 · 구강</span>
                 </a>
                 <a>
-                  <img src="/src/assets/icons/Type=Food.svg" alt="주방용품" />
+                  <img
+                    src="/src/assets/icons/Type=Food.svg"
+                    aria-hidden="true"
+                  />
                   <span>주방용품</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=HomeAppliances.svg"
-                    alt="가전제품"
+                    aria-hidden="true"
                   />
                   <span>가전제품</span>
                 </a>
                 <a>
-                  <img src="/src/assets/icons/Type=Dog.svg" alt="반려동물" />
+                  <img
+                    src="/src/assets/icons/Type=Dog.svg"
+                    aria-hidden="true"
+                  />
                   <span>반려동물</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Baby.svg"
-                    alt="베이비,키즈,완구"
+                    aria-hidden="true"
                   />
                   <span>베이비 · 키즈 · 완구</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Travel.svg"
-                    alt="여행,티켓"
+                    aria-hidden="true"
                   />
                   <span>여행 · 티켓</span>
                 </a>
@@ -249,148 +270,166 @@
             <li><a href="/">알뜰쇼핑</a></li>
             <li><a href="/">특가/혜택</a></li>
             <li>
-              <button class="menu_dawn">샛별·낮 <span>배송안내</span></button>
+              <a href="/" class="menu_dawn">샛별·낮 <span>배송안내</span></a>
             </li>
           </ul>
         </div>
         <div class="nav_scroll" style="display: none">
           <ul class="menu_scroll">
             <li>
-              <a href="/">카테고리</a>
+              <div>카테고리</div>
               <div class="category">
                 <a>
                   <img
                     src="/src/assets/icons/gift_thin_icon_171751.svg"
-                    alt="선물하기"
+                    aria-hidden="true"
                   />
                   <span>선물하기</span>
                 </a>
                 <a>
-                  <img src="/src/assets/icons/Type=_Vegetable.svg" alt="채소" />
+                  <img
+                    src="/src/assets/icons/Type=_Vegetable.svg"
+                    aria-hidden="true"
+                  />
                   <span>채소</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Fruit.svg"
-                    alt="과일,견과,쌀"
+                    aria-hidden="true"
                   />
                   <span>과일 · 견과 · 쌀</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=SeaFood.svg"
-                    alt="수산,해산,건어물"
+                    aria-hidden="true"
                   />
                   <span>수산 · 해산 · 건어물</span>
                 </a>
                 <a>
-                  <img src="/src/assets/icons/Type=Meet.svg" alt="정육,계란" />
+                  <img
+                    src="/src/assets/icons/Type=Meet.svg"
+                    aria-hidden="true"
+                  />
                   <span>정육 · 계란</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Cook.svg"
-                    alt="국,반찬,메인요리"
+                    aria-hidden="true"
                   />
                   <span>국 · 반찬 · 메인요리</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=_Salad.svg"
-                    alt="샐러드,간편식"
+                    aria-hidden="true"
                   />
                   <span>샐러드 · 간편식</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Oil.svg"
-                    alt="면,양념,오일"
+                    aria-hidden="true"
                   />
                   <span>면 · 양념 · 오일</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Coffee.svg"
-                    alt="생수,음료,우유,커피"
+                    aria-hidden="true"
                   />
                   <span>생수 · 음료 · 우유 · 커피</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Snack.svg"
-                    alt="간식,과자,떡"
+                    aria-hidden="true"
                   />
                   <span>간식 · 과자 · 떡</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Bread.svg"
-                    alt="베이커리,치즈,델리"
+                    aria-hidden="true"
                   />
                   <span>베이커리 · 치즈 · 델리</span>
                 </a>
                 <a>
-                  <img src="/src/assets/icons/Type=Health.svg" alt="건강식품" />
+                  <img
+                    src="/src/assets/icons/Type=Health.svg"
+                    aria-hidden="true"
+                  />
                   <span>건강식품</span>
                 </a>
                 <a>
-                  <img src="/src/assets/icons/Type=Wine.svg" alt="와인" />
+                  <img
+                    src="/src/assets/icons/Type=Wine.svg"
+                    aria-hidden="true"
+                  />
                   <span>와인</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=_TraditionalLiquor.svg"
-                    alt="전통주"
+                    aria-hidden="true"
                   />
                   <span>전통주</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=_Detergent.svg"
-                    alt="생활용품,리빙,캠핑"
+                    aria-hidden="true"
                   />
                   <span>생활용품 · 리빙 · 캠핑</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=_Cosmetics.svg"
-                    alt="스킨케어,메이크업"
+                    aria-hidden="true"
                   />
                   <span>스킨케어 · 메이크업</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=shampoo.svg"
-                    alt="헤어,바디,구강"
+                    aria-hidden="true"
                   />
                   <span>헤어 · 바디 · 구강</span>
                 </a>
                 <a>
-                  <img src="/src/assets/icons/Type=Food.svg" alt="주방용품" />
+                  <img
+                    src="/src/assets/icons/Type=Food.svg"
+                    aria-hidden="true"
+                  />
                   <span>주방용품</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=HomeAppliances.svg"
-                    alt="가전제품"
+                    aria-hidden="true"
                   />
                   <span>가전제품</span>
                 </a>
                 <a>
-                  <img src="/src/assets/icons/Type=Dog.svg" alt="반려동물" />
+                  <img
+                    src="/src/assets/icons/Type=Dog.svg"
+                    aria-hidden="true"
+                  />
                   <span>반려동물</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Baby.svg"
-                    alt="베이비,키즈,완구"
+                    aria-hidden="true"
                   />
                   <span>베이비 · 키즈 · 완구</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=Travel.svg"
-                    alt="여행,티켓"
+                    aria-hidden="true"
                   />
                   <span>여행 · 티켓</span>
                 </a>
@@ -416,7 +455,7 @@
             <li>
               <div class="icon_wrapper">
                 <div class="location_modal_wrapper">
-                  <img src="/src/assets/icons/Location.png" alt="" />
+                  <img src="/src/assets/icons/Location.png" alt="배송지 등록" />
                   <div class="location_modal">
                     <p>
                       <span>배송지를 등록하고</span><br />구매 가능한 상품을
@@ -430,12 +469,12 @@
                 </div>
                 <div>
                   <a href="">
-                    <img src="/src/assets/icons/Heart.png" alt="" />
+                    <img src="/src/assets/icons/Heart.png" alt="찜한 상품" />
                   </a>
                 </div>
                 <div>
                   <a href="">
-                    <img src="/src/assets/icons/Cart.png" alt="" />
+                    <img src="/src/assets/icons/Cart.png" alt="장바구니" />
                   </a>
                 </div>
               </div>


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정 / 기능에 대한 테스트)

### PR 내용 요약
header 컴포넌트 fixed nav z-index 추가 및 HTML 마크업 이미지 대체 텍스트 추가

### PR 상세
- product_list 페이지에서 fixed nav bar가 상품 목록 뒤에 배치되는 문제 해결 (.nav_scroll에 z-index: 10; 적용)
- 카테고리 아이콘 이미지 대체 텍스트 삭제 및 aria-hidden="true" 적용
- 최상단 배너 닫기 버튼 대체 텍스트 추가
- 배송지 등록, 찜한 상품, 장바구니 버튼 대체 텍스트 추가
- 카테고리 메뉴 a 태그에서 div 태그로 변경
- 배송지 등록 페이지 연결 버튼 button 태그에서 a 태그로 변경 및 CSS 수정

### 스크린샷
![Jan-08-2024 16-16-12](https://github.com/FRONTENDSCHOOL8/Karly/assets/90670695/14deec6d-4d8d-4e67-afc4-d1853f1dbd0a)

<img width="1680" alt="스크린샷 2024-01-08 오후 3 59 19" src="https://github.com/FRONTENDSCHOOL8/Karly/assets/90670695/8393941a-48f5-4f7d-a92e-267cbbeb5f82">

<img width="1680" alt="스크린샷 2024-01-08 오후 3 59 30" src="https://github.com/FRONTENDSCHOOL8/Karly/assets/90670695/5dedbb58-c84a-4dc9-a844-1e8f3acf557b">

## 이슈
resolves #35

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요 -->
<!-- ex) resolves #1 -->
