### PR TITLE
[modify] 헤더 컴포넌트 카테고리 아이콘 대체 텍스트 적용 및 링크 연결

### DIFF
--- a/src/components/header/header.css
+++ b/src/components/header/header.css
@@ -428,6 +428,8 @@ body {
   height: 775px;
 
   overflow-y: scroll;
+
+  z-index: 10;
 }
 
 .category a {

--- a/src/components/header/index.html
+++ b/src/components/header/index.html
@@ -111,160 +111,97 @@
         <div class="nav_origin">
           <ul class="menu">
             <li>
-              <div>카테고리</div>
+              <a href="/">카테고리</a>
               <div class="category">
                 <a>
-                  <img
-                    src="/src/assets/icons/gift_thin_icon_171751.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/gift_thin_icon_171751.svg" alt />
                   <span>선물하기</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=_Vegetable.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=_Vegetable.svg" alt />
                   <span>채소</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Fruit.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Fruit.svg" alt />
                   <span>과일 · 견과 · 쌀</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=SeaFood.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=SeaFood.svg" alt />
                   <span>수산 · 해산 · 건어물</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Meet.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Meet.svg" alt />
                   <span>정육 · 계란</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Cook.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Cook.svg" alt />
                   <span>국 · 반찬 · 메인요리</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=_Salad.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=_Salad.svg" alt />
                   <span>샐러드 · 간편식</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Oil.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Oil.svg" alt />
                   <span>면 · 양념 · 오일</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Coffee.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Coffee.svg" alt />
                   <span>생수 · 음료 · 우유 · 커피</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Snack.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Snack.svg" alt />
                   <span>간식 · 과자 · 떡</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Bread.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Bread.svg" alt />
                   <span>베이커리 · 치즈 · 델리</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Health.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Health.svg" alt />
                   <span>건강식품</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Wine.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Wine.svg" alt />
                   <span>와인</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=_TraditionalLiquor.svg"
-                    aria-hidden="true"
+                    alt
                   />
                   <span>전통주</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=_Detergent.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=_Detergent.svg" alt />
                   <span>생활용품 · 리빙 · 캠핑</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=_Cosmetics.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=_Cosmetics.svg" alt />
                   <span>스킨케어 · 메이크업</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=shampoo.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=shampoo.svg" alt />
                   <span>헤어 · 바디 · 구강</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Food.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Food.svg" alt />
                   <span>주방용품</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=HomeAppliances.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=HomeAppliances.svg" alt />
                   <span>가전제품</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Dog.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Dog.svg" alt />
                   <span>반려동물</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Baby.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Baby.svg" alt />
                   <span>베이비 · 키즈 · 완구</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Travel.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Travel.svg" alt />
                   <span>여행 · 티켓</span>
                 </a>
               </div>
@@ -274,167 +211,104 @@
             <li><a href="/src/pages/product_list/">알뜰쇼핑</a></li>
             <li><a href="/src/pages/product_list/">특가/혜택</a></li>
             <li>
-              <a href="/" class="menu_dawn">샛별·낮 <span>배송안내</span></a>
+              <button class="menu_dawn">샛별·낮 <span>배송안내</span></button>
             </li>
           </ul>
         </div>
         <div class="nav_scroll" style="display: none">
           <ul class="menu_scroll">
             <li>
-              <div>카테고리</div>
+              <a href="/">카테고리</a>
               <div class="category">
                 <a>
-                  <img
-                    src="/src/assets/icons/gift_thin_icon_171751.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/gift_thin_icon_171751.svg" alt />
                   <span>선물하기</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=_Vegetable.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=_Vegetable.svg" alt />
                   <span>채소</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Fruit.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Fruit.svg" alt />
                   <span>과일 · 견과 · 쌀</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=SeaFood.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=SeaFood.svg" alt />
                   <span>수산 · 해산 · 건어물</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Meet.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Meet.svg" alt />
                   <span>정육 · 계란</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Cook.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Cook.svg" alt />
                   <span>국 · 반찬 · 메인요리</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=_Salad.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=_Salad.svg" alt />
                   <span>샐러드 · 간편식</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Oil.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Oil.svg" alt />
                   <span>면 · 양념 · 오일</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Coffee.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Coffee.svg" alt />
                   <span>생수 · 음료 · 우유 · 커피</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Snack.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Snack.svg" alt />
                   <span>간식 · 과자 · 떡</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Bread.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Bread.svg" alt />
                   <span>베이커리 · 치즈 · 델리</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Health.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Health.svg" alt />
                   <span>건강식품</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Wine.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Wine.svg" alt />
                   <span>와인</span>
                 </a>
                 <a>
                   <img
                     src="/src/assets/icons/Type=_TraditionalLiquor.svg"
-                    aria-hidden="true"
+                    alt
                   />
                   <span>전통주</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=_Detergent.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=_Detergent.svg" alt />
                   <span>생활용품 · 리빙 · 캠핑</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=_Cosmetics.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=_Cosmetics.svg" alt />
                   <span>스킨케어 · 메이크업</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=shampoo.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=shampoo.svg" alt />
                   <span>헤어 · 바디 · 구강</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Food.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Food.svg" alt />
                   <span>주방용품</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=HomeAppliances.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=HomeAppliances.svg" alt />
                   <span>가전제품</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Dog.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Dog.svg" alt />
                   <span>반려동물</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Baby.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Baby.svg" alt />
                   <span>베이비 · 키즈 · 완구</span>
                 </a>
                 <a>
-                  <img
-                    src="/src/assets/icons/Type=Travel.svg"
-                    aria-hidden="true"
-                  />
+                  <img src="/src/assets/icons/Type=Travel.svg" alt />
                   <span>여행 · 티켓</span>
                 </a>
               </div>


### PR DESCRIPTION
header 컴포넌트 카테고리 CSS z-index 수정

## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정 / 기능에 대한 테스트)

### PR 내용 요약
헤더 컴포넌트 카테고리 아이콘 대체 텍스트 삭제 및 링크 연결

### PR 상세
<img width="610" alt="스크린샷 2024-01-11 오전 5 34 17" src="https://github.com/FRONTENDSCHOOL8/Karly/assets/90670695/f819abc5-9fe6-412a-8d86-b1c8b4b0ffe3">

- **카테고리 대체 텍스트 이슈**
카테고리의 아이콘이 들어가는(스크린 리더가 읽으면 안 됨) img 태그에 alt 속성을 빼고 aria-hidden 처리를 하니까 HTML 유효성 검사에서 error가 발생함
-> alt 속성값을 공백으로 적용하고 aria-hidden은 모두 삭제

- **카테고리 CSS 이슈**
메인 페이지의 배너 캐러셀 뒤로 카테고리 목록이 사라지는 CSS 이슈도 함께 해결함
-> 카테고리 div에 `z-index: 10;`

### 스크린샷
web developer로 모든 이미지를 alt로 대체 옵션을 적용한 모습 (아이콘 대체 텍스트 삭제됨)
<img width="281" alt="스크린샷 2024-01-11 오전 5 26 06" src="https://github.com/FRONTENDSCHOOL8/Karly/assets/90670695/12719747-03d0-46eb-985e-c5f8004f73e5">

## 이슈
resolves #66 

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요 -->
<!-- ex) resolves #1 -->
