### PR TITLE
[modify] merge 병합 오류 - getPbImageURL.js

### DIFF
--- a/src/lib/utils/getPbImageURL.js
+++ b/src/lib/utils/getPbImageURL.js
@@ -1,5 +1,11 @@
 export function getPbImageURL(item, fileName = 'image', index = 0) {
-  return `${import.meta.env.VITE_PB_API}/files/${item.collectionId}/${
-    item.id
-  }/${item[fileName][index]}`;
+  if (!Array.isArray(item[fileName])) {
+    return `${import.meta.env.VITE_PB_API}/files/${item.collectionId}/${
+      item.id
+    }/${item[fileName]}`;
+  } else {
+    return `${import.meta.env.VITE_PB_API}/files/${item.collectionId}/${
+      item.id
+    }/${item[fileName][index]}`;
+  }
 }


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정 / 기능에 대한 테스트)

### PR 내용 요약
merge 병합 오류 - getPbImageURL.js

### PR 상세
merge할 때 최신화 된 파일이 과거의 파일로 덮어씌워짐
-> 되돌림

### 스크린샷

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요 -->
<!-- ex) resolves #1 -->
